### PR TITLE
Feature/make editable value in pickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Add the following dependency to your `build.gradle` / `build.gradle.kts` file:
 For Groovy - `build.gradle`:
 ````
 dependencies {
-    implementation 'com.github.KvColorPalette:KvColorPicker-Android:2.0.0'
+    implementation 'com.github.KvColorPalette:KvColorPicker-Android:2.1.0'
 }
 ````
 For Kotlin DSL - `build.gradle.kts`:
 ````
 dependencies {
-    implementation("com.github.KvColorPalette:KvColorPicker-Android:2.0.0")
+    implementation("com.github.KvColorPalette:KvColorPicker-Android:2.1.0")
 }
 ````
 

--- a/gradle/version-catalog/libs.versions.toml
+++ b/gradle/version-catalog/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 minSdkVersion = "26"
 compilerSdkVersion = "35"
-targetSdkVersion = "35"
 jvmVersion = "21"
 
 agp = "8.7.3"
@@ -12,13 +11,12 @@ junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.10.0"
-composeBom = "2025.01.00"
+activityCompose = "1.10.1"
+composeBom = "2025.02.00"
 appcompat = "1.7.0"
 material = "1.12.0"
-composeMaterial = "1.7.6"
-composeNavigation = "2.8.5"
-kvColorPalette = "2.1.0"
+composeMaterial = "1.7.8"
+kvColorPalette = "2.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -36,7 +34,6 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "composeMaterial"}
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
-androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "composeNavigation" }
 
 kv-color-palette = { group = "com.github.KvColorPalette", name = "KvColorPalette-Android", version.ref = "kvColorPalette" }
 

--- a/kv-color-picker/gradle.properties
+++ b/kv-color-picker/gradle.properties
@@ -1,3 +1,3 @@
 kvColorPaletteGroupId=com.github.KvColorPalette
 kvColorPickerArtifactId=KvColorPicker-Android
-kvColorPickerVersion=2.0.0
+kvColorPickerVersion=2.1.0

--- a/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/extension/Extension.kt
+++ b/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/extension/Extension.kt
@@ -1,8 +1,0 @@
-package com.kavi.droid.color.picker.extension
-
-/**
- * Converts a float value in the range [0, 1] to an integer color component in the range [0, 255].
- *
- * @return The integer representation of the color component.
- */
-internal fun Float.toColorRangeInt(): Int = (this * 255 + 0.5f).toInt()


### PR DESCRIPTION
# Editable color values
From this change, in RGB-A color picker consumer can edit the RED, GREEN or BLUE color values from slider as well as manually as a text field too.

#### commits:
* [Update the color picker version](https://github.com/KvColorPalette/KvColorPicker-Android/commit/3b32cd69450ea558a81721be0c6ee06fc7fbf2ac)
* [Update all available dependencies to latest versions.](https://github.com/KvColorPalette/KvColorPicker-Android/commit/3e40183fbfa3b353d48a73397dd688be379e19d6)
* [Introduce text fields in to RGB-A color picker.](https://github.com/KvColorPalette/KvColorPicker-Android/commit/4e227c91efe776cbf45ad29e0df6d3375f8da146)