### PR TITLE
Update KvColorPalette-Android v3.2.0 version

### DIFF
--- a/gradle/version-catalog/libs.versions.toml
+++ b/gradle/version-catalog/libs.versions.toml
@@ -16,7 +16,7 @@ composeBom = "2025.02.00"
 appcompat = "1.7.0"
 material = "1.12.0"
 composeMaterial = "1.7.8"
-kvColorPalette = "2.1.1"
+kvColorPalette = "3.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/kv-color-picker/gradle.properties
+++ b/kv-color-picker/gradle.properties
@@ -1,3 +1,3 @@
 kvColorPaletteGroupId=com.github.KvColorPalette
 kvColorPickerArtifactId=KvColorPicker-Android
-kvColorPickerVersion=2.1.0
+kvColorPickerVersion=2.2.0

--- a/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/KvColorPickerBottomSheet.kt
+++ b/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/KvColorPickerBottomSheet.kt
@@ -61,7 +61,8 @@ fun KvColorPickerBottomSheet(showSheet: MutableState<Boolean>, sheetState: Sheet
             showSheet.value = false
         },
         sheetState = sheetState,
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = MaterialTheme.colorScheme.background,
+        scrimColor = MaterialTheme.colorScheme.onSurface.copy(alpha = .5f)
     ) {
         Column {
             var selectedColor by remember { mutableStateOf(Color.Black) }

--- a/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/KvColorPickerBottomSheet.kt
+++ b/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/KvColorPickerBottomSheet.kt
@@ -47,6 +47,7 @@ import com.kavi.droid.color.picker.ui.pickers.RGBAColorPicker
  * RGBAColorPicker: This a color picker with RGB and Alpha values. Consumer can create their own color by changing
  * RED, GREEN and BLUE values in a color.
  *
+ * @param lastSelectedColor: Color: variable to pass last selected color.
  * @param showSheet: MutableState<Boolean>: State variable to show and hide bottom sheet.
  * @param sheetState: SheetState: State variable to control the bottom sheet.
  * @param onColorSelected: (selectedColor: Color) -> Unit: Callback to invoke when a color is selected.
@@ -55,7 +56,11 @@ import com.kavi.droid.color.picker.ui.pickers.RGBAColorPicker
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun KvColorPickerBottomSheet(showSheet: MutableState<Boolean>, sheetState: SheetState, onColorSelected: (selectedColor: Color) -> Unit) {
+fun KvColorPickerBottomSheet(
+    lastSelectedColor: Color = Color.White,
+    showSheet: MutableState<Boolean>,
+    sheetState: SheetState,
+    onColorSelected: (selectedColor: Color) -> Unit) {
     ModalBottomSheet (
         onDismissRequest = {
             showSheet.value = false
@@ -65,7 +70,7 @@ fun KvColorPickerBottomSheet(showSheet: MutableState<Boolean>, sheetState: Sheet
         scrimColor = MaterialTheme.colorScheme.onSurface.copy(alpha = .5f)
     ) {
         Column {
-            var selectedColor by remember { mutableStateOf(Color.Black) }
+            var selectedColor by remember { mutableStateOf(lastSelectedColor) }
             val colorHex = remember { mutableStateOf(TextFieldValue("#000000")) }
             var tabIndex by remember { mutableIntStateOf(0) }
             val tabs = listOf(
@@ -115,6 +120,7 @@ fun KvColorPickerBottomSheet(showSheet: MutableState<Boolean>, sheetState: Sheet
             when(tabIndex) {
                 0 -> RGBAColorPicker(
                     modifier = Modifier.padding(16.dp),
+                    lastSelectedColor = selectedColor,
                     onColorSelected = {
                         selectedColor = it
                         colorHex.value = TextFieldValue(ColorUtil.getHex(it))
@@ -122,6 +128,7 @@ fun KvColorPickerBottomSheet(showSheet: MutableState<Boolean>, sheetState: Sheet
                 )
                 1 -> GridColorPicker(
                     modifier = Modifier.padding(16.dp),
+                    lastSelectedColor = selectedColor,
                     onColorSelected = {
                         selectedColor = it
                         colorHex.value = TextFieldValue(ColorUtil.getHex(it))
@@ -129,6 +136,7 @@ fun KvColorPickerBottomSheet(showSheet: MutableState<Boolean>, sheetState: Sheet
                 )
                 2 -> HSLAColorPicker(
                     modifier = Modifier.padding(16.dp),
+                    lastSelectedColor = selectedColor,
                     onColorSelected = {
                         selectedColor = it
                         colorHex.value = TextFieldValue(ColorUtil.getHex(it))

--- a/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/common/CommonUI.kt
+++ b/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/common/CommonUI.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.kavi.droid.color.palette.KvColorPalette
@@ -307,11 +308,21 @@ internal fun SelectedColorDetail(color: Color, colorHex: MutableState<TextFieldV
  * @param onSelect: (color: Color) -> Unit: Callback to invoke when a color is selected.
  */
 @Composable
-internal fun ColorColum(givenColor: KvColor, selectedColor: Color, onSelect: (color: Color) -> Unit) {
+internal fun ColorColum(
+    boxSize: Dp,
+    givenColor: KvColor,
+    selectedColor: Color,
+    onSelect: (color: Color) -> Unit
+) {
     val colors = KvColorPalette.instance.generateColorPalette(givenColor = givenColor)
     Column {
         colors.forEach {
-            ColorBox(givenColor = it, selectedColor = selectedColor, onSelect = onSelect)
+            ColorBox(
+                boxSize = boxSize,
+                givenColor = it,
+                selectedColor = selectedColor,
+                onSelect = onSelect
+            )
         }
     }
 }
@@ -319,12 +330,13 @@ internal fun ColorColum(givenColor: KvColor, selectedColor: Color, onSelect: (co
 /**
  * A composable function that displays a single color box.
  *
+ * @param boxSize: Dp: Size of the color box.
  * @param givenColor: Color: The color to display.
  * @param selectedColor: Color: The selected color to highlight.
  * @param onSelect: (color: Color) -> Unit: Callback to invoke when a color is selected.
  */
 @Composable
-internal fun ColorBox(givenColor: Color, selectedColor: Color?, onSelect: (color: Color) -> Unit) {
+internal fun ColorBox(boxSize: Dp = 24.dp, givenColor: Color, selectedColor: Color?, onSelect: (color: Color) -> Unit) {
     var isSelected by remember { mutableStateOf(false) }
 
     selectedColor?.let {
@@ -333,8 +345,8 @@ internal fun ColorBox(givenColor: Color, selectedColor: Color?, onSelect: (color
 
     Box(
         modifier = Modifier
-            .width(24.dp)
-            .height(24.dp)
+            .width(boxSize)
+            .height(boxSize)
             .background(givenColor, RectangleShape)
             .clickable {
                 isSelected = true

--- a/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/pickers/GridColorPicker.kt
+++ b/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/pickers/GridColorPicker.kt
@@ -3,6 +3,7 @@ package com.kavi.droid.color.picker.ui.pickers
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -76,88 +77,108 @@ fun GridColorPicker(modifier: Modifier = Modifier, onColorSelected: (selectedCol
                 fontSize = 12.sp
             )
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 16.dp, start = 4.dp, end = 4.dp, bottom = 12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
-            ) {
-                ColorColum(
-                    givenColor = MatPackage.MatRed,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatRose,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatLPurple,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatDPurple,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatDBlue,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatLBlue,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatLLBlue,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatLCyan,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatDCyan,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatDGreen,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatLGreen,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatLLGreen,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatYellow,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatGold,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
-                ColorColum(
-                    givenColor = MatPackage.MatOrange,
-                    selectedColor = selectedColor,
-                    onSelect = onSelectColor
-                )
+            BoxWithConstraints {
+                val screenWidth = maxWidth
+                val boxSize = screenWidth * .065f
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp, start = 4.dp, end = 4.dp, bottom = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatRed,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatRose,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatLPurple,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatDPurple,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatDBlue,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatLBlue,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatLLBlue,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatLCyan,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatDCyan,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatDGreen,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatLGreen,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatLLGreen,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatYellow,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatGold,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                    ColorColum(
+                        boxSize = boxSize,
+                        givenColor = MatPackage.MatOrange,
+                        selectedColor = selectedColor,
+                        onSelect = onSelectColor
+                    )
+                }
             }
         }
     }

--- a/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/pickers/GridColorPicker.kt
+++ b/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/pickers/GridColorPicker.kt
@@ -1,5 +1,6 @@
 package com.kavi.droid.color.picker.ui.pickers
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -36,15 +37,21 @@ import com.kavi.droid.color.picker.ui.common.ColorColum
  * 16 predefined major colors and those color's 10 color variances.
  *
  * @param modifier: Modifier: The modifier to apply to this layout.
+ * @param lastSelectedColor: Color: variable to pass last selected color.
  * @param onColorSelected: (selectedColor: Color) -> Unit: Callback to invoke when a color is selected.
  *
  * @return @Composable: A grid UI to select colors.
  */
+@SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
-fun GridColorPicker(modifier: Modifier = Modifier, onColorSelected: (selectedColor: Color) -> Unit) {
+fun GridColorPicker(
+    modifier: Modifier = Modifier,
+    lastSelectedColor: Color = Color.White,
+    onColorSelected: (selectedColor: Color) -> Unit
+) {
 
-    var selectedColor by remember { mutableStateOf(Color.White) }
-    val colorHex = remember { mutableStateOf(TextFieldValue("#ffffff")) }
+    var selectedColor by remember { mutableStateOf(lastSelectedColor) }
+    val colorHex = remember { mutableStateOf(TextFieldValue(ColorUtil.getHex(lastSelectedColor))) }
 
     val onSelectColor: (color: Color) -> Unit = {
         selectedColor = it

--- a/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/pickers/HSLAColorPicker.kt
+++ b/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/pickers/HSLAColorPicker.kt
@@ -40,18 +40,22 @@ import com.kavi.droid.color.picker.ui.common.SliderHue
  * By adjusting these values, consumer can select or generate their desired color.
  *
  * @param modifier: Modifier: The modifier to apply to this layout.
+ * @param lastSelectedColor: Color: variable to pass last selected color.
  * @param onColorSelected: (selectedColor: Color) -> Unit: Callback to invoke when a color is selected.
  *
  * @return @Composable: A color picker UI for selecting HSL-A colors.
  */
 @Composable
-fun HSLAColorPicker(modifier: Modifier = Modifier, onColorSelected: (selectedColor: Color) -> Unit) {
-
+fun HSLAColorPicker(
+    modifier: Modifier = Modifier,
+    lastSelectedColor: Color = Color.White,
+    onColorSelected: (selectedColor: Color) -> Unit
+) {
     // State variables for HSL-A values
-    val hue = rememberSaveable { mutableFloatStateOf(0f) }
-    val saturation = rememberSaveable { mutableFloatStateOf(0f) }
-    val lightness = rememberSaveable { mutableFloatStateOf(0.5f) }
-    val alpha = rememberSaveable { mutableFloatStateOf(1f) }
+    val hue = rememberSaveable { mutableFloatStateOf(lastSelectedColor.hsl.hue) }
+    val saturation = rememberSaveable { mutableFloatStateOf(lastSelectedColor.hsl.saturation) }
+    val lightness = rememberSaveable { mutableFloatStateOf(lastSelectedColor.hsl.lightness) }
+    val alpha = rememberSaveable { mutableFloatStateOf(lastSelectedColor.alpha) }
 
     val colorHex = remember { mutableStateOf(TextFieldValue("")) }
 

--- a/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/pickers/RGBAColorPicker.kt
+++ b/kv-color-picker/src/main/kotlin/com/kavi/droid/color/picker/ui/pickers/RGBAColorPicker.kt
@@ -37,17 +37,22 @@ import com.kavi.droid.color.picker.ui.common.ColorSlider
  * By adjusting these values, consumer can select or generate your desired color.
  *
  * @param modifier: Modifier: The modifier to apply to this layout.
+ * @param lastSelectedColor: Color: variable to pass last selected color.
  * @param onColorSelected: (selectedColor: Color) -> Unit: Callback to invoke when a color is selected.
  *
  * @return @Composable: A color picker UI for selecting RGB-A colors.
  */
 @Composable
-fun RGBAColorPicker(modifier: Modifier = Modifier, onColorSelected: (selectedColor: Color) -> Unit) {
+fun RGBAColorPicker (
+    modifier: Modifier = Modifier,
+    lastSelectedColor: Color = Color.White,
+    onColorSelected: (selectedColor: Color) -> Unit
+) {
     // State variables for RGB-A values
-    val red = rememberSaveable { mutableFloatStateOf(0f) }
-    val green = rememberSaveable { mutableFloatStateOf(0f) }
-    val blue = rememberSaveable { mutableFloatStateOf(0f) }
-    val alpha = rememberSaveable { mutableFloatStateOf(1f) }
+    val red = rememberSaveable { mutableFloatStateOf(lastSelectedColor.red) }
+    val green = rememberSaveable { mutableFloatStateOf(lastSelectedColor.green) }
+    val blue = rememberSaveable { mutableFloatStateOf(lastSelectedColor.blue) }
+    val alpha = rememberSaveable { mutableFloatStateOf(lastSelectedColor.alpha) }
 
     val colorHex = remember { mutableStateOf(TextFieldValue("")) }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -40,3 +40,11 @@ dependencyResolutionManagement {
         maven { url = URI("https://jitpack.io") }
     }
 }
+
+// This is for local development (Use this as a gradle composite build)
+/*includeBuild("../KvColorPalette-Android") {
+    dependencySubstitution {
+        substitute(module("com.github.KvColorPalette:KvColorPalette-Android"))
+            .using(project(":kv-color-palette"))
+    }
+}*/


### PR DESCRIPTION
# Update KvColorPalette-Android v3.2.0 version
From this change, `KvColorPicker-Android` library start to use `KvColorPalette-Android` library v3.2.0. This will take some updates to over the top colors in the theming.

# commits:
* [Start to use KvColorPalette-Android v3.2.0 version in KvColorPicker-A…](https://github.com/KvColorPalette/KvColorPicker-Android/commit/1ffc0213521f3cd05ddb95791c6bc271b82e9fb4)